### PR TITLE
Add generic type hints to `BaseEnv`

### DIFF
--- a/fights/base.py
+++ b/fights/base.py
@@ -1,16 +1,9 @@
-import sys
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, Optional, Tuple
+from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar
 
 from numpy.typing import ArrayLike
 
-if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias
-else:
-    from typing import TypeAlias
-
-
-State: TypeAlias = Any
+S = TypeVar("S", bound="BaseState")
 
 
 class BaseState(ABC):
@@ -30,7 +23,7 @@ class BaseState(ABC):
         ...
 
 
-class BaseEnv(ABC):
+class BaseEnv(ABC, Generic[S]):
     @property
     @abstractmethod
     def env_id(self) -> Tuple[str, int]:
@@ -42,27 +35,27 @@ class BaseEnv(ABC):
     @abstractmethod
     def step(
         self,
-        state: State,
+        state: S,
         agent_id: int,
         action: ArrayLike,
         *,
-        pre_step_fn: Optional[Callable[[State, int, ArrayLike], None]] = None,
-        post_step_fn: Optional[Callable[[State, int, ArrayLike], None]] = None,
-    ) -> State:
+        pre_step_fn: Optional[Callable[[S, int, ArrayLike], None]] = None,
+        post_step_fn: Optional[Callable[[S, int, ArrayLike], None]] = None,
+    ) -> S:
         """
         Step through the environment.
         """
         ...
 
     @abstractmethod
-    def initialize_state(self) -> BaseState:
+    def initialize_state(self) -> S:
         """
         Initialize state.
         """
         ...
 
 
-class BaseAgent(ABC):
+class BaseAgent(ABC, Generic[S]):
     @property
     @abstractmethod
     def env_id(self) -> Tuple[str, int]:
@@ -72,7 +65,7 @@ class BaseAgent(ABC):
         ...
 
     @abstractmethod
-    def __call__(self, state: State) -> ArrayLike:
+    def __call__(self, state: S) -> ArrayLike:
         """
         Return the calculated agent action based on state input.
         """

--- a/fights/envs/__init__.py
+++ b/fights/envs/__init__.py
@@ -1,10 +1,10 @@
-from typing import Tuple, Type
+from typing import Tuple, Type, cast
 
 from ..base import BaseEnv, BaseState
 from .puoribor import PuoriborEnv, PuoriborState
 
 
-def resolve(name: str) -> Tuple[Type[BaseEnv], Type[BaseState]]:
+def resolve(name: str) -> Tuple[Type[BaseEnv[BaseState]], Type[BaseState]]:
     """
     Resolve environment and state classes with environment name.
 
@@ -17,4 +17,4 @@ def resolve(name: str) -> Tuple[Type[BaseEnv], Type[BaseState]]:
     mappings = {"puoribor": (PuoriborEnv, PuoriborState)}
     if name not in mappings:
         raise ValueError(f"environment with name {name} not found")
-    return mappings[name]
+    return cast(Tuple[Type[BaseEnv[BaseState]], Type[BaseState]], mappings[name])

--- a/fights/envs/puoribor.py
+++ b/fights/envs/puoribor.py
@@ -165,7 +165,7 @@ class PuoriborState(BaseState):
         )
 
 
-class PuoriborEnv(BaseEnv):
+class PuoriborEnv(BaseEnv[PuoriborState]):
     env_id = ("puoribor", 1)  # type: ignore
     """
     Environment identifier in the form of ``(name, version)``.


### PR DESCRIPTION
By introducing type variable with `BaseState` bound, meaningful typechecking is possible.
