### PR TITLE
Fix type issue caused by `agent_id` property

### DIFF
--- a/fights/base.py
+++ b/fights/base.py
@@ -64,11 +64,10 @@ class BaseAgent(ABC, Generic[S]):
         """
         ...
 
-    @property
     @abstractmethod
-    def agent_id(self) -> int:
+    def __init__(self, agent_id: int) -> None:
         """
-        Agent identifier.
+        Initialize an agent.
         """
         ...
 


### PR DESCRIPTION
The `agent_id` will be passed to `__init__` instead.
