### PR TITLE
Add generic for action type

### DIFF
--- a/docs/fights.base.rst
+++ b/docs/fights.base.rst
@@ -4,13 +4,20 @@ fights.base
 
 .. currentmodule:: fights.base
 
+.. autodata:: fights.base.S
+
+.. autodata:: fights.base.A
+
 .. autoclass:: fights.base.BaseState
+   :show-inheritance:
    :members:
 
 .. autoclass:: fights.base.BaseEnv
+   :show-inheritance:
    :members:
 
 .. autoclass:: fights.base.BaseAgent
+   :show-inheritance:
    :members:
    :special-members:
    :exclude-members: __weakref__

--- a/docs/fights.envs.pouribor.rst
+++ b/docs/fights.envs.pouribor.rst
@@ -17,7 +17,7 @@ Environment
 Action
 ^^^^^^
 
-.. autoclass:: fights.envs.puoribor.PuoriborAction
+.. autodata:: fights.envs.puoribor.PuoriborAction
 
 ^^^^^
 State

--- a/fights/base.py
+++ b/fights/base.py
@@ -1,9 +1,19 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import Callable, Dict, Generic, Optional, Tuple, TypeVar
 
 from numpy.typing import ArrayLike
 
 S = TypeVar("S", bound="BaseState")
+"""
+A type variable for state type with bound ``BaseState``
+"""
+
+A = TypeVar("A", bound=ArrayLike)
+"""
+A type variable for action type with bound ``ArrayLike``
+"""
 
 
 class BaseState(ABC):
@@ -23,7 +33,7 @@ class BaseState(ABC):
         ...
 
 
-class BaseEnv(ABC, Generic[S]):
+class BaseEnv(ABC, Generic[S, A]):
     @property
     @abstractmethod
     def env_id(self) -> Tuple[str, int]:
@@ -37,10 +47,10 @@ class BaseEnv(ABC, Generic[S]):
         self,
         state: S,
         agent_id: int,
-        action: ArrayLike,
+        action: A,
         *,
-        pre_step_fn: Optional[Callable[[S, int, ArrayLike], None]] = None,
-        post_step_fn: Optional[Callable[[S, int, ArrayLike], None]] = None,
+        pre_step_fn: Optional[Callable[[S, int, A], None]] = None,
+        post_step_fn: Optional[Callable[[S, int, A], None]] = None,
     ) -> S:
         """
         Step through the environment.
@@ -55,7 +65,7 @@ class BaseEnv(ABC, Generic[S]):
         ...
 
 
-class BaseAgent(ABC, Generic[S]):
+class BaseAgent(ABC, Generic[S, A]):
     @property
     @abstractmethod
     def env_id(self) -> Tuple[str, int]:
@@ -72,7 +82,7 @@ class BaseAgent(ABC, Generic[S]):
         ...
 
     @abstractmethod
-    def __call__(self, state: S) -> ArrayLike:
+    def __call__(self, state: S) -> A:
         """
         Return the calculated agent action based on state input.
         """

--- a/fights/envs/__init__.py
+++ b/fights/envs/__init__.py
@@ -1,10 +1,14 @@
+from __future__ import annotations
+
 from typing import Tuple, Type, cast
+
+from numpy.typing import ArrayLike
 
 from ..base import BaseEnv, BaseState
 from .puoribor import PuoriborEnv, PuoriborState
 
 
-def resolve(name: str) -> Tuple[Type[BaseEnv[BaseState]], Type[BaseState]]:
+def resolve(name: str) -> Tuple[Type[BaseEnv[BaseState, ArrayLike]], Type[BaseState]]:
     """
     Resolve environment and state classes with environment name.
 
@@ -17,4 +21,6 @@ def resolve(name: str) -> Tuple[Type[BaseEnv[BaseState]], Type[BaseState]]:
     mappings = {"puoribor": (PuoriborEnv, PuoriborState)}
     if name not in mappings:
         raise ValueError(f"environment with name {name} not found")
-    return cast(Tuple[Type[BaseEnv[BaseState]], Type[BaseState]], mappings[name])
+    return cast(
+        Tuple[Type[BaseEnv[BaseState, ArrayLike]], Type[BaseState]], mappings[name]
+    )

--- a/fights/envs/puoribor.py
+++ b/fights/envs/puoribor.py
@@ -165,7 +165,7 @@ class PuoriborState(BaseState):
         )
 
 
-class PuoriborEnv(BaseEnv[PuoriborState]):
+class PuoriborEnv(BaseEnv[PuoriborState, PuoriborAction]):
     env_id = ("puoribor", 1)  # type: ignore
     """
     Environment identifier in the form of ``(name, version)``.


### PR DESCRIPTION
Now sphinx docs looks a lot better, except the type variable `A` part in `fights.base`.
I guess sphinx doesn't simplify aliases in `TypeVar` bound.